### PR TITLE
Implement retroactive bugfix in update & delete training session functions

### DIFF
--- a/public/assets/js/firebase.js
+++ b/public/assets/js/firebase.js
@@ -544,6 +544,27 @@ export async function createTrainingSession(uid, trainingSession) {
         transaction.delete(exerciseItemRef);
       }
     }
+
+    // RETROACTIVE BUGFIX: Remove old exercise item documents whose ID
+    // numbers are not zero-padded, if any.
+    for (let i = 0; i < oldExerciseCount; i++) {
+      // Ordinal position of the exercise item in the exercises list,
+      // WITHOUT ZERO-PADDING (the old, wrong way).
+      const ordinalPosition = String(i);
+
+      if (ordinalPosition.length < 2) {
+        // If the ordinal position is a single-digit number, check if
+        // there is an exercise item document whose ID is set to that
+        // unpadded number and delete it.
+        const unpaddedExerciseItemRef = doc(exercisesRef, ordinalPosition);
+        const unpaddedExerciseItemDoc = await transaction.get(
+            unpaddedExerciseItemRef.withConverter(exerciseItemConverter));
+  
+        if (unpaddedExerciseItemDoc.exists()) {
+          transaction.delete(unpaddedExerciseItemRef);
+        }
+      }
+    }
   });
 }
 


### PR DESCRIPTION
- `updateTrainingSession`: Delete exercise items with unpadded ID numbers (if any) when updating training session.
- `deleteTrainingSession`: Delete exercise items with updadded ID numbers (if any) when deleting training session. Had to rewrite function to use a Firestore transaction instead of a write batch.